### PR TITLE
Bug 1546848 - Keep going despite failed parses. r=mccr8,kats

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -249,7 +249,7 @@ pub fn parse(include_dirs: &Vec<PathBuf>, file_names: Vec<PathBuf>) -> Option<Ha
                 Err(message) => {
                     print_include_context(&include_context);
                     println!("{} {}", curr_file.display(), message);
-                    return None
+                    continue
                 }
             };
 


### PR DESCRIPTION
This just changes the return to a continue, but it allows IPDL parsing to be best-ish effort which is enough to make the indexing produce some results instead of absolutely no results.

This change has been working acceptably on the "fancy" branch where I have some other changes to improve the file mapping to handle the de-virtualization of various methods that would come in a different pull request in ~1 week.