### PR TITLE
Fix parse() to actually match the API SearchFox expects.

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -330,6 +330,6 @@ pub fn parse_with_errors(
 pub fn parse(
     include_dirs: &Vec<PathBuf>,
     file_names: Vec<PathBuf>,
-) -> HashMap<TUId, TranslationUnit> {
-    parse_internal(include_dirs, file_names, /* ignore_errors = */ true).unwrap()
+) -> Option<HashMap<TUId, TranslationUnit>> {
+    parse_internal(include_dirs, file_names, /* ignore_errors = */ true).ok()
 }


### PR DESCRIPTION
I accidentally changed the type of parse() in my previous commits. Also it would crash if the parse failed. This fixes that so that SearchFox will actually build now.