### PR TITLE
Print out errors when ignoring them.

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -255,6 +255,10 @@ fn parse_internal(
             Ok(fc) => fc,
             Err(_) => {
                 if ignore_errors {
+                    println!(
+                        "error: can't locate file specified on the command line `{}'",
+                        f.display()
+                    );
                     continue;
                 } else {
                     return Err(format!(
@@ -281,6 +285,9 @@ fn parse_internal(
                 Ok(tu) => tu,
                 Err(message) => {
                     if ignore_errors {
+                        let mut new_message = include_context_to_string(&include_context);
+                        new_message.push_str(&format!("{} {}", curr_file.display(), message));
+                        println!("  {}", new_message);
                         continue;
                     } else {
                         let mut new_message = include_context_to_string(&include_context);


### PR DESCRIPTION
This is not ideal as a default behavior, but we are already printing
out the filename as we parse it, so it is consistent!  This makes it
easier for us to figure out why an IPDL file is not indexed in
searchfox by checking the index-log.  This could be better addressed
by introducing a concept of an error record that the parser could emit
into an analysis file so that we could display what's broken when
looking at the file in searchfox, potentially on an opt-in basis.