### PR TITLE
Add naive support for `[ManualAlloc, ChildImpl=virtual]` annotations.

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -346,6 +346,7 @@ pub struct Protocol {
     pub managers: Vec<Identifier>,
     pub manages: Vec<Identifier>,
     pub messages: Vec<MessageDecl>,
+    pub annotations: Vec<(Identifier, Option<Identifier>)>,
 }
 
 impl Protocol {
@@ -355,6 +356,7 @@ impl Protocol {
         managers: Vec<Identifier>,
         manages: Vec<Identifier>,
         decls: Vec<MessageDecl>,
+        annotations: Vec<(Identifier, Option<Identifier>)>,
     ) -> Protocol {
         Protocol {
             send_semantics: send_semantics,
@@ -362,6 +364,7 @@ impl Protocol {
             managers: managers,
             manages: manages,
             messages: decls,
+            annotations,
         }
     }
 }

--- a/src/ipdl.lalrpop
+++ b/src/ipdl.lalrpop
@@ -11,6 +11,18 @@ use parser::{TopLevelDecl, ParserState, PreambleStmt};
 
 grammar<'a>(parser_state: &ParserState<'a>);
 
+// This is from the calculator example
+// https://github.com/lalrpop/lalrpop/blob/master/doc/calculator/src/calculator5.lalrpop
+Comma<T>: Vec<T> = {
+    <mut v:(<T> ",")*> <e:T?> => match e {
+        None=> v,
+        Some(e) => {
+            v.push(e);
+            v
+        }
+    }
+};
+
 //-----------------------------------------------------------------------------
 
 STRING: String = <s:r#""[^"\n]*""#> => String::from(s);
@@ -189,7 +201,18 @@ UnionDecl: (Namespace, Vec<TypeSpec>) = {
     }
 };
 
+AnnotationPair: (Identifier, Option<Identifier>) = {
+    <key:Identifier> <value:("=" <Identifier>)?> => (key, value)
+}
+
+AnnotationList = Comma<AnnotationPair>;
+
+ProtocolAnnotations: Vec<(Identifier, Option<Identifier>)> = {
+    "[" <annos:AnnotationList> "]" => annos
+};
+
 ProtocolDefn: (Namespace, Protocol) = {
+    <a:ProtocolAnnotations?>
     <q:ProtocolSendSemanticsQual?> "protocol" <name:Identifier> "{"
         <managers:ManagersStmtOpt> <manages:ManagesStmt*> <decls:MessageDeclThing*> "}" ";" =>
     {
@@ -200,7 +223,8 @@ ProtocolDefn: (Namespace, Protocol) = {
         }
 
         let (nested, send_semantics) = q.unwrap_or((Nesting::None, SendSemantics::Async));
-        (Namespace::new(name), Protocol::new(send_semantics, nested, managers, manages, decls))
+        let annos = a.unwrap_or_else(|| vec![]);
+        (Namespace::new(name), Protocol::new(send_semantics, nested, managers, manages, decls, annos))
     },
 };
 

--- a/tests/ok/Pmanual.ipdl
+++ b/tests/ok/Pmanual.ipdl
@@ -1,0 +1,5 @@
+[ManualDealloc]
+sync protocol Pmanual {
+child:
+    async __delete__();
+};

--- a/tests/ok/Pmanualvirtual.ipdl
+++ b/tests/ok/Pmanualvirtual.ipdl
@@ -1,0 +1,5 @@
+[ManualDealloc, ChildImpl=virtual, ParentImpl=Virtual]
+sync protocol Pmanualvirtual {
+child:
+    async __delete__();
+};


### PR DESCRIPTION
The parser does not seem to like annotations inclusive of both the
`[ManualAlloc]` type added in
https://bugzilla.mozilla.org/show_bug.cgi?id=1736371 and the variations
that also include list of annotations in the patch that look like
`[ManualDealloc, ChildImpl=virtual, ParentImpl=virtual]`.

My efforts here are to try and get this to parse and technically
produce something usable, but I wouldn't be surprised if someone wanted
to properly consume the annotations that they would want something that
looks more strongly typed.  But this is an AST so maybe this is fine?