### PR TITLE
Update IPDL parser to Aug 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,40 +8,40 @@ user at the moment is [Searchfox](https://searchfox.org).
 
 # Syncing the Rust parser with Firefox
 
-* Get an up-to-date mozilla-central checkout of Firefox.
+- Get an up-to-date mozilla-central checkout of Firefox.
 
-* Make sure the existing tests all pass with Firefox's IPDL parser. To
-do this from your mozilla-central checkout, go to
-$OBJDIR/ipc/ipdl/test and run make check. These tests are run as part
-of the build now, so this shouldn't be an issue.
+- Make sure the existing tests all pass with Firefox's IPDL parser. To
+  do this from your mozilla-central checkout, go to
+  `$OBJDIR/ipc/ipdl/test` and run `make check`. These tests are run as part
+  of the build now, so this shouldn't be an issue.
 
-* Delete all files in the tests/ok/ and tests/error directories. Copy
-the .ipdl and .ipdlh files from ipc/ipdl/test/ipdl/ok/ and
-ipc/ipdl/test/ipdl/error/ from a mozilla-central checkout into the
-corresponding directories you just deleted files from. Delete
-PasyncMessageListed.ipdl, unknownIntrMessage.ipdl and
-unknownSyncMessage.ipdl from the error/ directory, because these fail
-due to the sync message checker, which has not been implemented in
-Rust.
+- Delete all files in the `tests/ok/` and `tests/error` directories. Copy
+  the `.ipdl` and `.ipdlh` files from `ipc/ipdl/test/ipdl/ok/` and
+  `ipc/ipdl/test/ipdl/error/` from a mozilla-central checkout into the
+  corresponding directories you just deleted files from.
 
-* You can run these tests with `cargo test`. It is likely that some
-tests will fail.
+- You can run these tests with `cargo test`. It is likely that some
+  tests will fail.
 
-* Look at the list of revisions for
-[parser.py](https://hg.mozilla.org/mozilla-central/log/tip/ipc/ipdl/ipdl/parser.py)
-and [type.py](https://hg.mozilla.org/mozilla-central/log/tip/ipc/ipdl/ipdl/type.py)
-to find the set of revisions since the last time the Rust
-IPDL parser was updated.
+- Look at the list of revisions for
+  [parser.py](https://hg.mozilla.org/mozilla-central/log/tip/ipc/ipdl/ipdl/parser.py)
+  and [type.py](https://hg.mozilla.org/mozilla-central/log/tip/ipc/ipdl/ipdl/type.py)
+  to find the set of revisions since the last time the Rust
+  IPDL parser was updated.
 
-* For each such revision, make sure there is a front end test. You can
+- For each such revision, make sure there is a front end test. You can
   do this by looking at the commit, and also by using SearchFox to see
-if there are any .ipdl files in the test directory that contain the
-feature. Some times tests are added in follow up bugs. These tests
-should valid states and failure cases for anything added to
-type.py. If a test is missing, please write one and land it in
-mozilla-central.
+  if there are any .ipdl files in the test directory that contain the
+  feature. Some times tests are added in follow up bugs. These tests
+  should valid states and failure cases for anything added to
+  type.py. If a test is missing, please write one and land it in
+  mozilla-central.
 
-* Once there are unit tests for every new feature, and all of them are
-passing, you should make sure the parser works on all IPDL files in
-the tree. See directions for that in make_test_command.py in this
-directory.
+- Once there are unit tests for every new feature, and all of them are
+  passing, you should make sure the parser works on all IPDL files in
+  the tree. See directions for that in make_test_command.py in this
+  directory.
+
+- Note that the sync message checker has not been implemented, so any
+  `error` test that relies on that will never pass. Any tests that are
+  expected to fail can be added to `ERROR_PASS_TESTS` in `smoke_test.rs`.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -244,6 +244,7 @@ pub enum Priority {
     Vsync,
     Mediumhigh,
     Control,
+    Low,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -76,47 +76,32 @@ pub enum AttributeValue {
 pub type Attributes = HashMap<String, (Location, AttributeValue)>;
 
 #[derive(Debug)]
+pub enum TypeSpecModifier {
+    Maybe,
+    Array,
+    UniquePtr,
+}
+
+#[derive(Debug)]
 pub struct TypeSpec {
     pub loc: Location,
     pub spec: String,
-    pub array: bool,
-    pub maybe: bool,
     pub nullable: bool,
-    pub uniqueptr: bool,
+    pub modifiers: Vec<TypeSpecModifier>,
 }
 
 impl TypeSpec {
-    pub fn new(id: Identifier) -> TypeSpec {
+    pub fn new(id: Identifier, nullable: bool) -> TypeSpec {
         TypeSpec {
             loc: id.loc,
             spec: id.id,
-            array: false,
-            maybe: false,
-            nullable: false,
-            uniqueptr: false,
+            nullable: nullable,
+            modifiers: Vec::new(),
         }
     }
 
-    // XXX Get rid of these setters if the fields are just public anyways?
-
-    pub fn set_array(mut self, is_array: bool) -> TypeSpec {
-        self.array = is_array;
-        self
-    }
-
-    pub fn set_maybe(mut self, is_maybe: bool) -> TypeSpec {
-        self.maybe = is_maybe;
-        self
-    }
-
-    pub fn set_nullable(mut self, is_nullable: bool) -> TypeSpec {
-        self.nullable = is_nullable;
-        self
-    }
-
-    pub fn set_uniqueptr(mut self, is_uniqueptr: bool) -> TypeSpec {
-        self.uniqueptr = is_uniqueptr;
-        self
+    pub fn add_modifier(&mut self, m: TypeSpecModifier) {
+        self.modifiers.push(m);
     }
 
     pub fn loc(&self) -> &Location {

--- a/src/ipdl.lalrpop
+++ b/src/ipdl.lalrpop
@@ -5,7 +5,7 @@
 use ast::{Attributes, AttributeValue, CxxTypeKind, Direction, FileType, Identifier,
           Location, MessageDecl, Namespace,
           Param, Protocol, QualifiedId, SendSemantics,
-          StructField, TranslationUnit, TypeSpec, UsingStmt};
+          StructField, TranslationUnit, TypeSpecModifier, TypeSpec, UsingStmt};
 
 use parser::{TopLevelDecl, ParserState, PreambleStmt};
 
@@ -308,24 +308,26 @@ Param: Param = {
 };
 
 Type: TypeSpec = {
-    // only actor types are nullable; we check this in the type checker
-    <is_nullable: "nullable"?> <t:BasicType> => t.set_nullable(is_nullable.is_some())
+    <t:BasicType> => t,
+    <mut t:Type> "?" => {
+        t.add_modifier(TypeSpecModifier::Maybe);
+        t
+    },
+    <mut t:Type> "[" "]" => {
+        t.add_modifier(TypeSpecModifier::Array);
+        t
+    },
+    "UniquePtr" "<" <mut t:Type> ">" => {
+        t.add_modifier(TypeSpecModifier::UniquePtr);
+        t
+    },
 };
 
-// ID == CxxType; we forbid qnames here,
-// in favor of the |using| declaration
 BasicType: TypeSpec = {
-    <id:CxxID> <is_array: ("[" "]")?> => {
-        TypeSpec::new(id).set_array(is_array.is_some())
-    },
-    <id:CxxID> "?" => {
-        TypeSpec::new(id).set_maybe(true)
-    },
-    <uniqueptr: CxxUniquePtrInst> => {
-        TypeSpec::new(uniqueptr).set_uniqueptr(true)
+    <is_nullable: "nullable"?> <id:CxxID> => {
+        TypeSpec::new(id, is_nullable.is_some())
     },
 };
-
 
 //--------------------
 // C++ stuff
@@ -348,12 +350,5 @@ CxxID: Identifier = {
 CxxTemplateInst: Identifier = {
     <t_name:Identifier> "<" <arg:Identifier> ">" => {
         Identifier::new(t_name.id + "<" + &arg.id + ">", t_name.loc)
-    }
-};
-
-CxxUniquePtrInst: Identifier = {
-    <start:@L> "UniquePtr" "<" <arg:Identifier> ">" => {
-        let start_loc = parser_state.resolve_location(start);
-        Identifier::new(arg.id, start_loc)
     }
 };

--- a/src/type_check.rs
+++ b/src/type_check.rs
@@ -190,10 +190,6 @@ impl IPDLType {
         let mut errors = Errors::none();
         let mut itype = self.clone();
 
-        if type_spec.uniqueptr {
-            itype = IPDLType::UniquePtrType(Box::new(itype))
-        }
-
         if let &IPDLType::ProtocolType(ref p) = self {
             itype = IPDLType::ActorType(p.clone())
         }
@@ -218,12 +214,12 @@ impl IPDLType {
             }
         }
 
-        if type_spec.array {
-            itype = IPDLType::ArrayType(Box::new(itype))
-        }
-
-        if type_spec.maybe {
-            itype = IPDLType::MaybeType(Box::new(itype))
+        for modifier in &type_spec.modifiers {
+            itype = match modifier {
+                &TypeSpecModifier::Array => IPDLType::ArrayType(Box::new(itype)),
+                &TypeSpecModifier::Maybe => IPDLType::MaybeType(Box::new(itype)),
+                &TypeSpecModifier::UniquePtr => IPDLType::UniquePtrType(Box::new(itype)),
+            }
         }
 
         (errors, itype)

--- a/src/type_check.rs
+++ b/src/type_check.rs
@@ -827,11 +827,13 @@ fn declare_protocol(
     let protocol_attributes: AttributeSpec = {
         let process_keywords = || {
             [
+                // The IPDL process options from proc_options in type.py.
                 "any",
                 "anychild",
                 "anydom",
                 "compositor",
-                // ---
+                // The proc-typename fields from this file:
+                // xpcom/geckoprocesstypes_generator/geckoprocesstypes/__init__.py
                 "Parent",
                 "Content",
                 "IPDLUnitTest",
@@ -840,7 +842,6 @@ fn declare_protocol(
                 "VR",
                 "RDD",
                 "Socket",
-                "RemoteSandboxBroker",
                 "ForkServer",
                 "Utility",
             ]

--- a/src/type_check.rs
+++ b/src/type_check.rs
@@ -455,6 +455,7 @@ fn get_prio_impl(attributes: &Attributes, key: &str) -> Option<Priority> {
             ("vsync", Priority::Vsync),
             ("mediumhigh", Priority::Mediumhigh),
             ("control", Priority::Control),
+            ("low", Priority::Low),
         ]),
         |_| Priority::Normal,
     )
@@ -1165,6 +1166,7 @@ fn gather_decls_message(
                 AttributeSpecValue::Keyword("vsync"),
                 AttributeSpecValue::Keyword("mediumhigh"),
                 AttributeSpecValue::Keyword("control"),
+                AttributeSpecValue::Keyword("low"),
             ])
         };
 

--- a/tests/error/ExtendedAttrInvalidPriorityValue.ipdl
+++ b/tests/error/ExtendedAttrInvalidPriorityValue.ipdl
@@ -1,4 +1,4 @@
-//error: invalid value for attribute `Priority', expected one of: normal, input, vsync, mediumhigh, control
+//error: invalid value for attribute `Priority', expected one of: normal, input, vsync, mediumhigh, control, low
 
 [ChildProc=any]
 protocol ExtendedAttrInvalidPriorityValue {

--- a/tests/error/PUniquePtrRecursive.ipdl
+++ b/tests/error/PUniquePtrRecursive.ipdl
@@ -1,6 +1,0 @@
-//error: bad syntax near `UniquePtr'
-
-[ChildProc=any]
-protocol PUniquePtrRecursive {
-child: async Msg( UniquePtr< UniquePtr<int> > aa);
-};

--- a/tests/error/PUnknownProc.ipdl
+++ b/tests/error/PUnknownProc.ipdl
@@ -1,4 +1,4 @@
-//error: invalid value for attribute `ChildProc', expected one of: any, anychild, anydom, compositor, Parent, Content, IPDLUnitTest, GMPlugin, GPU, VR, RDD, Socket, RemoteSandboxBroker, ForkServer, Utility
+//error: invalid value for attribute `ChildProc', expected one of: any, anychild, anydom, compositor, Parent, Content, IPDLUnitTest, GMPlugin, GPU, VR, RDD, Socket, ForkServer, Utility
 
 [ChildProc=unknowntype]
 protocol PUnknownProc {

--- a/tests/error/array_Recursive.ipdl
+++ b/tests/error/array_Recursive.ipdl
@@ -1,6 +1,0 @@
-//error: bad syntax near `['
-
-[ChildProc=any]
-protocol array_Recursive {
-child: async Msg(int[][] aa);
-};

--- a/tests/error/maybe_Recursive.ipdl
+++ b/tests/error/maybe_Recursive.ipdl
@@ -1,6 +1,0 @@
-//error: bad syntax near `?'
-
-[ChildProc=any]
-protocol maybe_Recursive {
-child: async Msg(int?? aa);
-};

--- a/tests/ok/PNullable.ipdl
+++ b/tests/ok/PNullable.ipdl
@@ -4,9 +4,11 @@ union Union {
     nullable PNullable;
     nullable PNullable[];
     nullable PNullable?;
+    UniquePtr<nullable PNullable>;
     nullable nsIURI;
     nullable nsIURI[];
     nullable nsIURI?;
+    UniquePtr<nullable nsIURI>;
 };
 
 [ChildProc=any]
@@ -15,8 +17,10 @@ child:
     async Msg(nullable PNullable n);
     async Msg2(nullable PNullable[] N);
     async Msg3(nullable PNullable? n);
-    async Msg4(nullable nsIURI u);
-    async Msg5(nullable nsIURI[] u);
-    async Msg6(nullable nsIURI? u);
-    async Msg7(Union u);
+    async Msg4(UniquePtr<nullable PNullable> n);
+    async Msg5(nullable nsIURI u);
+    async Msg6(nullable nsIURI[] u);
+    async Msg7(nullable nsIURI? u);
+    async Msg8(UniquePtr<nullable nsIURI> n);
+    async Msg9(Union u);
 };

--- a/tests/ok/PUniquePtrRecursive.ipdl
+++ b/tests/ok/PUniquePtrRecursive.ipdl
@@ -1,0 +1,6 @@
+[ChildProc=any]
+protocol PUniquePtrRecursive {
+child:
+  async Msg1( UniquePtr< UniquePtr<int> > aa);
+  async Msg2(UniquePtr<UniquePtr<UniquePtr<UniquePtr<UniquePtr<int>>>>> aa);
+};

--- a/tests/ok/Parray_Maybe.ipdl
+++ b/tests/ok/Parray_Maybe.ipdl
@@ -1,0 +1,6 @@
+[ChildProc=any]
+protocol Parray_Maybe {
+child:
+  async Msg1(int?[] aa);
+  async Msg2(int?[]?[]?[]?[]?[]? aa);
+};

--- a/tests/ok/Parray_Recursive.ipdl
+++ b/tests/ok/Parray_Recursive.ipdl
@@ -1,0 +1,6 @@
+[ChildProc=any]
+protocol Parray_Recursive {
+child:
+  async Msg1(int[][] aa);
+  async Msg2(int[][][][][][][] aa);
+};

--- a/tests/ok/Parray_UniquePtr.ipdl
+++ b/tests/ok/Parray_UniquePtr.ipdl
@@ -1,0 +1,7 @@
+[ChildProc=any]
+protocol Parray_UniquePtr {
+child:
+  async Msg1(UniquePtr<int>[] aa);
+  async Msg2(UniquePtr<int[]>[] aa);
+  async Msg3(UniquePtr<UniquePtr<int[]>[]>[] aa);
+};

--- a/tests/ok/Pmaybe_Recursive.ipdl
+++ b/tests/ok/Pmaybe_Recursive.ipdl
@@ -1,0 +1,6 @@
+[ChildProc=any]
+protocol Pmaybe_Recursive {
+child:
+  async Msg1(int?? aa);
+  async Msg2(int??????? aa);
+};

--- a/tests/ok/Prio.ipdl
+++ b/tests/ok/Prio.ipdl
@@ -7,6 +7,7 @@ child:
   [Priority=input] async InputPrio();
   [Priority=mediumhigh] async MediumHighPrio();
   [Priority=control] async ControlPrio();
+  [Priority=low] async LowPrio();
   [ReplyPriority=control] async ControlPrioReturns() returns (bool aValue);
   [Priority=normal, ReplyPriority=control] async NormalControlPrioReturns() returns (bool aValue);
 };


### PR DESCRIPTION
This fixes a few minor issues in the README, fixes 2 minor issues with the type checker, and, most importantly, updates the actual parser to match the changes in bug 1985635. Bug 1985635 improves support for nested type specs (eg allows `UniquePtr<Foo>[]`), and is backwards compatible.