### PR TITLE
Update to Rust edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "ipdl_parser"
 version = "0.1.0"
 authors = ["Andrew McCreight <continuation@gmail.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2024"
 
 # Add a dependency on the regex crate; this is not
 # needed if you are writing your own tokenizer by
@@ -16,4 +16,4 @@ lalrpop = "0.20.2"
 
 [dependencies]
 getopts = "0.2.14"
-lalrpop-util = "0.20.2"
+lalrpop-util = { version = "0.20.2", features = [ "lexer" ] }


### PR DESCRIPTION
There's only one warning about drop order changing in src/parser.rs:197:5:
```
warning: relative drop order changing in Rust 2024
   --> src/parser.rs:197:5
    |
180 |     let mut f = File::open(file_name).unwrap();
    |         -----
    |         |
    |         `f` calls a custom destructor
    |         `f` will be dropped later as of Edition 2024
...
197 |     TranslationUnitParser::new()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     |
    |     this value will be stored in a temporary; let us call it `#1`
    |     up until Edition 2021 `#1` is dropped last but will be dropped earlier in Edition 2024
...
233 | }
    | - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
    = note: `#1` may invoke a custom destructor because it contains a trait object
note: `f` invokes this custom destructor
   --> /nix/store/h27rgraygvzlvgjjk30n7fljd7i5hd5g-rust-stable-2026-01-22/lib/rustlib/src/rust/library/std/src/os/fd/owned.rs:188:1
    |
188 | impl Drop for OwnedFd {
    | ^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
    = note: `--force-warn tail-expr-drop-order` implied by `--force-warn rust-2024-compatibility`
```

I think it's harmess.